### PR TITLE
added iPython notebook as a dependency so bndl-compute-shell can started

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,7 @@ install_requires = [
     'yappi<=0.93',
     'lz4',
     'cyheapq',
+    'ipython==6.2.1'
 ]
 
 if sys.version_info < (3, 5):


### PR DESCRIPTION
This dependency is required to start bndl-compute-shell from the documentation.